### PR TITLE
Fix divide by zero error for averages on an empty collection

### DIFF
--- a/lib/data-table/table.rb
+++ b/lib/data-table/table.rb
@@ -423,6 +423,8 @@ module DataTable
     end
 
     def calculate_avg(collection, column_name)
+      return 0 if collection.empty?
+
       sum = calculate_sum(collection, column_name)
       sum / collection.size
     end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -138,6 +138,13 @@ describe DataTable::Table do
       expect(data_table.render).to \
       eq(%{<table id='' class='data_table ' cellspacing='0' cellpadding='0'><caption></caption><thead><tr></tr></thead><tr><td class='empty_data_table' colspan='0'>#{text}</td></tr></table>})
     end
+
+    it "avoids dividing by zero" do
+      data_table.column :power_level
+      data_table.total :power_level, :avg, 0
+      data_table.calculate_totals!
+      expect(data_table.total_calculations).to eq([{:power_level=>0}])
+    end
   end
 
   context 'with a more complicated setup' do


### PR DESCRIPTION
If you set up `avg` totals but pass an empty collection, you'd get an unhandled exception, due to an attempted divide by zero. This PR fixes that exception and just returns 0 in this case (although it shouldn't matter, because totals aren't rendered for empty collections anyway).

This fixes an internal error report which I can share with org members, but won't post here because it's a public repo.